### PR TITLE
add "staticlib" to crate-type in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Onur Kılıç <kiliconu@itu.edu.tr>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
 multicore = ["sapling-crypto/multicore", "bellman/multicore"]


### PR DESCRIPTION
This results in cargo building e.g. `target/debug/librln.a`, which is suitable for static linking.