### PR TITLE
add staticlib to crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Onur Kılıç <kiliconu@itu.edu.tr>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
 multicore = ["sapling-crypto/multicore", "bellman/multicore"]


### PR DESCRIPTION
With this PR, `cargo build` will also generate a `.a` static library, useful for linking without requiring dynamic dependencies